### PR TITLE
Fix restore warning in build

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -3,9 +3,6 @@ name: dev-build
 # Run this workflow on push to PRs and all branches except master.  
 on:
   pull_request:
-  push:
-    branches-ignore: 
-      - 'master'
   workflow_dispatch:
     
 jobs:
@@ -15,7 +12,7 @@ jobs:
     runs-on: windows-latest
 
     env:
-      Build_Version: 1.0.999.${{ github.run_number }}           # Dummy versioning, breaks SemVer. Can't add "-dev" tag to VSIX version numbers
+      Build_Version: 1.0.999                                    # Dummy version on PR artifact
       Solution_Name: GitBranchDiffer.sln                        
       Build_Configuration: Release
       Build_Platform: 'Any CPU'
@@ -55,5 +52,5 @@ jobs:
     - name: Upload build artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: GitBranchDiffer-${{ env.Build_Version }}
+        name: GitBranchDiffer-${{ env.Build_Version }}-Test
         path: ${{ env.VSIX_Path }}

--- a/GitBranchDiffer/GitBranchDiffer.csproj
+++ b/GitBranchDiffer/GitBranchDiffer.csproj
@@ -82,7 +82,7 @@
       <Version>5.0.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.SDK" Version="16.0.206" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="16.9.2017" />
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="16.10.7" />
     <PackageReference Include="System.ComponentModel.Composition">
       <Version>5.0.0</Version>
     </PackageReference>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,12 +1,5 @@
 #CI-only pipeline: Build, test and create the artifact. Currently disabled 
-trigger:
-  branches:
-    exclude:
-      - '*'
-  paths:
-    exclude:
-      - 'README.md'
-      - 'README-Marketplace.md'
+trigger: none
 
 pool:
   vmImage: 'windows-latest'


### PR DESCRIPTION
Updated VSSDK nuget package so msbuild --restore does not throw warning on older package not found
Trying to disable Azure pipelines in this branch did not work