### PR TITLE
Build publish pipeline

### DIFF
--- a/.github/workflows/buildPublish.yml
+++ b/.github/workflows/buildPublish.yml
@@ -1,16 +1,68 @@
 name: buildPublish
 
+# Release steps: 
+# Create git tag, update version numbers in all .yml build definitions in 'master' branch
+# Push into 'origin:master', wait for CI build to finish and test the artifact from CI build
+# Merge branch 'master' into 'release', push into 'origin:release', which will trigger this pipeline
+
 on:
   push:
     branches: 
-      - 'release/**'      
-
-  # Allows you to run this workflow manually from the Actions tab
-  workflow_dispatch:
+      - 'release'
 
 jobs:
+
+  build:
+
+    runs-on: windows-latest
+
+    env:
+      Build_Version: 1.0.${{ github.run_number }}
+      Solution_Name: GitBranchDiffer.sln                        
+      Build_Configuration: Release
+      Build_Platform: 'Any CPU'
+      VSIX_Path: GitBranchDiffer\bin\Release\GitBranchDiffer.vsix
+      Test_Project_Path: your-test-project-path                 # Replace with the path to your test project 
+      
+
+    steps:
+
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    # Install the .NET Core workload, probably not needed
+    - name: Install .NET Core
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 5.0.x
+
+    # Add  MSBuild to the PATH: https://github.com/microsoft/setup-msbuild
+    - name: Setup MSBuild.exe
+      uses: microsoft/setup-msbuild@v1.0.2
+      
+    # TODO: Also add a step to automatically create a Github Release from latest Tag in 'release' branch
+    # TODO: Powershell to update 'More Info' URL in extension manifest to the lastest Github Release
+    - name: Update VSIX version in extension manifest
+      shell: powershell
+      run: .\VersionUpdater.ps1 $env:Build_Version
+
+    # Restore the solution
+    - name: Restore GitBranchDiffer
+      run: msbuild $env:Solution_Name /t:Restore /p:Configuration=$env:Build_Configuration /v:m
+
+    # Build the solution
+    - name: Build GitBranchDiffer
+      run: msbuild $env:Solution_Name /p:Configuration=$env:Build_Configuration /p:Platform=$env:Build_Platform /v:m
+
+    # Upload the MSIX package: https://github.com/marketplace/actions/upload-artifact
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: GitBranchDiffer-${{ env.Build_Version }}
+        path: ${{ env.VSIX_Path }}
   
-  # TODO: Also add a step to automatically create a Github Release  
   publish:
     
     runs-on: windows-2019

--- a/.github/workflows/buildPublish.yml
+++ b/.github/workflows/buildPublish.yml
@@ -1,15 +1,14 @@
 name: buildPublish
 
 # Release steps: 
-# Create git tag, update version numbers in all .yml build definitions in 'master' branch
-# Push into 'origin:master', wait for CI build to finish and test the artifact from CI build
-# Merge branch 'master' into 'release', push into 'origin:release', which will trigger this pipeline
+# On 'master' branch, create git tag with pattern: v{Major}.{Minor}.{Path}
+# To publish release: git push origin master v{Major}.{Minor}.{Path}
 
 on:
+  workflow_dispatch: # TODO Remove once testing is done  
   push:
-    branches: 
-      - 'release'
-
+    tags:
+      - 'v*.*.*'
 jobs:
 
   build:
@@ -17,13 +16,12 @@ jobs:
     runs-on: windows-latest
 
     env:
-      Build_Version: 1.0.${{ github.run_number }}
+      Build_Version: 0.0.0                                      # Must be updated by parsing version from tag name
       Solution_Name: GitBranchDiffer.sln                        
       Build_Configuration: Release
       Build_Platform: 'Any CPU'
       VSIX_Path: GitBranchDiffer\bin\Release\GitBranchDiffer.vsix
-      Test_Project_Path: your-test-project-path                 # Replace with the path to your test project 
-      
+      Test_Project_Path: your-test-project-path                 # Replace with the path to your test project       
 
     steps:
 
@@ -38,12 +36,31 @@ jobs:
       with:
         dotnet-version: 5.0.x
 
-    # Add  MSBuild to the PATH: https://github.com/microsoft/setup-msbuild
+    # Add  MSBuild to the PATH
     - name: Setup MSBuild.exe
       uses: microsoft/setup-msbuild@v1.0.2
+
+    - name: Determine version number
+      shell: powershell
+      run: 
+        |
+        $version = .\VersionParser.ps1
+        echo "Build_Version=$versionString" >> $GITHUB_ENV
       
-    # TODO: Also add a step to automatically create a Github Release from latest Tag in 'release' branch
-    # TODO: Powershell to update 'More Info' URL in extension manifest to the lastest Github Release
+    # Create a Github Release from latest Tag in 'release' branch.
+    - name: Create Github Release
+      id: create_gh_release
+      uses: softprops/action-gh-release@v1
+      with: 
+        prerelease: true    # TODO Remove once testing is done  
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    # Powershell script to update 'More Info' URL in extension manifest to the lastest Github Release created above
+    - name: Update MoreInfo URL in extension manifest
+      shell: powershell
+      run: .\InfoURLUpdater.ps1 ${{ steps.create_gh_release.output.url }}
+
     - name: Update VSIX version in extension manifest
       shell: powershell
       run: .\VersionUpdater.ps1 $env:Build_Version
@@ -56,24 +73,53 @@ jobs:
     - name: Build GitBranchDiffer
       run: msbuild $env:Solution_Name /p:Configuration=$env:Build_Configuration /p:Platform=$env:Build_Platform /v:m
 
-    # Upload the MSIX package: https://github.com/marketplace/actions/upload-artifact
-    - name: Upload build artifacts
+    # Upload the VSIX package
+    - name: Upload artifact to workflow
       uses: actions/upload-artifact@v2
       with:
-        name: GitBranchDiffer-${{ env.Build_Version }}
+        name: GitBranchDiffer
         path: ${{ env.VSIX_Path }}
+
+    # Add a step to upload artifact as asset to the Github Release created above
+    - name: Upload artifact as Github Release Asset
+      uses: actions/upload-release-asset@v1
+      env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_gh_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
+        asset_path: ${{ env.VSIX_Path }}
+        asset_name: GitBranchDiffer.zip
+        asset_content_type: application/zip
+
   
   publish:
     
     runs-on: windows-2019
+    needs: build
     
     env:
       Publisher_Name: SajalVerma
       PAT: ${{ secrets.VS_MARKETPLACE_ACCESS_TOKEN }}
       Vs2019ToolsPath: 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VSSDK\VisualStudioIntegration\Tools\Bin\'
+      Release_Directory: GitBranchDiffer\bin\Release\
 
     steps:
+
+        # Download the build artifact to artifacts folder in working directory
+      - name: Download the build artifact
+        uses: actions/download-artifact@v2
+        with:
+            name: GitBranchDiffer
+            path: .\artifacts
+
+      - name: View artifact directory
+        shell: powershell
+        run: dir .\artifacts
       
+      - name: View Release directory
+        shell: powershell
+        run: dir $env:Release_Directory
+
       - name: Login to marketplace
         shell : powershell
         run: |     

--- a/GitBranchDiffer.sln
+++ b/GitBranchDiffer.sln
@@ -10,6 +10,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{855A4207-609F-4E68-B763-439FE6018E91}"
 	ProjectSection(SolutionItems) = preProject
 		azure-pipelines.yml = azure-pipelines.yml
+		InfoURLUpdater.ps1 = InfoURLUpdater.ps1
 		LICENSE.md = LICENSE.md
 		LICENSE.txt = LICENSE.txt
 		PublishManifest.json = PublishManifest.json

--- a/GitBranchDiffer.sln
+++ b/GitBranchDiffer.sln
@@ -16,6 +16,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		PublishManifest.json = PublishManifest.json
 		README-Marketplace.md = README-Marketplace.md
 		README.md = README.md
+		VersionParser.ps1 = VersionParser.ps1
 		VersionUpdater.ps1 = VersionUpdater.ps1
 	EndProjectSection
 EndProject

--- a/VersionInfoURLUpdater.ps1
+++ b/VersionInfoURLUpdater.ps1
@@ -1,12 +1,12 @@
-﻿$version = $args[0]
+﻿$infoUrl = $args[0]
 
 $manifestFile = Resolve-Path $PSScriptRoot\GitBranchDiffer\source.extension.vsixmanifest
 
 [xml]$manifestFileContent = Get-Content $manifestFile
 
-$manifestFileContent.PackageManifest.Metadata.Identity.Version = $version
+$manifestFileContent.PackageManifest.Metadata.MoreInfo = $infoUrl
 
 $manifestFileContent.Save($manifestFile)
 
-Write-Host "Updated version in VSIX Manifest to "$version
+Write-Host "Updated MoreInfo URL in VSIX manifest to "$infoUrl
 

--- a/VersionParser.ps1
+++ b/VersionParser.ps1
@@ -1,0 +1,9 @@
+﻿
+$tagName = git describe --tag --abbrev=0
+
+# Tag pattern is v*.*.*
+$versionString = $tagname.Substring(1, $tagname.length - 1)
+
+Write-Host "Version number from latest Git tag: "$versionString
+
+return $versionString


### PR DESCRIPTION
1. Trigger publish on pushing a tag with pattern v*.*.*
2. Parse the tag and remove 'v', this will be the version number which will be published
3. Added step for automatic creation of GH release, upload the VSIX as artifact
4. The URL of the GH Release will be set to the VSIX manifest, along with existing script that updates version number
5. Download artifact in publish job, maybe not even needed.

To test, we only create pre-release for now 