### PR TITLE
Locate git repository upwards

### DIFF
--- a/src/BranchDiffer.Git/Core/GitRepositoryFactory.cs
+++ b/src/BranchDiffer.Git/Core/GitRepositoryFactory.cs
@@ -20,6 +20,7 @@ namespace BranchDiffer.Git.Core
         private IGitRepository DoCreate(string directoryPath)
         {
             GitRepository createdRepository;
+            string solutionPath = directoryPath;
             try
             {
                 // locate .git repo upwards
@@ -30,9 +31,9 @@ namespace BranchDiffer.Git.Core
                 Repository native = new Repository(directoryPath);
                 createdRepository = new GitRepository(native);
             }
-            catch (RepositoryNotFoundException nativeException)
+            catch (RepositoryNotFoundException)
             {
-                throw new GitRepoNotFoundException(nativeException.Message);
+                throw new GitRepoNotFoundException($"Unable to find a Git repository at this solution's directory ({solutionPath}) or it's parent directories.");
             }
 
             return createdRepository;

--- a/src/BranchDiffer.Git/Core/GitRepositoryFactory.cs
+++ b/src/BranchDiffer.Git/Core/GitRepositoryFactory.cs
@@ -24,9 +24,9 @@ namespace BranchDiffer.Git.Core
             {
                 // locate .git repo upwards
                 while(!Directory.Exists(Path.Combine(directoryPath, ".git")) && !File.Exists(Path.Combine(directoryPath, ".git")) && Path.GetPathRoot(directoryPath) != directoryPath)
-				{
+                {
                     directoryPath = Path.GetDirectoryName(directoryPath);
-				}
+                }
                 Repository native = new Repository(directoryPath);
                 createdRepository = new GitRepository(native);
             }

--- a/src/BranchDiffer.Git/Core/GitRepositoryFactory.cs
+++ b/src/BranchDiffer.Git/Core/GitRepositoryFactory.cs
@@ -1,6 +1,7 @@
 ﻿using BranchDiffer.Git.Exceptions;
 using BranchDiffer.Git.Models.LibGit2SharpModels;
 using LibGit2Sharp;
+using System.IO;
 
 namespace BranchDiffer.Git.Core
 {
@@ -21,6 +22,11 @@ namespace BranchDiffer.Git.Core
             GitRepository createdRepository;
             try
             {
+                // locate .git repo upwards
+                while(!Directory.Exists(Path.Combine(directoryPath, ".git")) && !File.Exists(Path.Combine(directoryPath, ".git")) && Path.GetPathRoot(directoryPath) != directoryPath)
+				{
+                    directoryPath = Path.GetDirectoryName(directoryPath);
+				}
                 Repository native = new Repository(directoryPath);
                 createdRepository = new GitRepository(native);
             }

--- a/src/BranchDiffer.VS.Shared/BranchDiff/BranchDiffFilterProvider.cs
+++ b/src/BranchDiffer.VS.Shared/BranchDiff/BranchDiffFilterProvider.cs
@@ -103,8 +103,6 @@ namespace BranchDiffer.VS.BranchDiff
                     {
                         try
                         {
-                            // BUG: The solution directory path may not always be the Git repo path! Solution can be in a subdirectory of the Git-Repo directory.
-                            // Git repo could be setup higher up. Write a service to find the Git repo upwards in the heirarchy and pass that here.
                             this.changeSet = this.branchDiffWorker.GenerateDiff(this.solutionDirectory, this.package.BranchToDiffAgainst);
                         }
                         catch (GitOperationException e)


### PR DESCRIPTION
this patch locates the git repository - a real one or a work tree - upwards in the directory tree, if the solution file is not in the root of the repository.