### PR TITLE
Fixes issue #32 and other bugs

### DIFF
--- a/src/BranchDiffer.Git/Configuration/DIContainer.cs
+++ b/src/BranchDiffer.Git/Configuration/DIContainer.cs
@@ -6,8 +6,7 @@ using Microsoft.Extensions.DependencyInjection;
 namespace BranchDiffer.Git.Configuration
 {
     /// <summary>
-    /// Singleton DI container of the Git project.
-    /// Not thread safe, not sure if async working of plugin could cause problems here.
+    /// Resolves DI dependencies in BranchDiff.Git project
     /// </summary>
     public static class DIContainer
     {

--- a/src/BranchDiffer.VS.Shared/BranchDiff/BranchDiffFilterProvider.cs
+++ b/src/BranchDiffer.VS.Shared/BranchDiff/BranchDiffFilterProvider.cs
@@ -66,8 +66,6 @@ namespace BranchDiffer.VS.Shared.BranchDiff
             private readonly IVsHierarchyItemCollectionProvider vsHierarchyItemCollectionProvider;            
             private readonly IGitBranchDifferPackage package;
             private readonly string solutionDirectory;
-
-            // Resolvable dependencies...
             private readonly GitBranchDiffController branchDiffWorker;
             private readonly BranchDiffFilterValidator branchDiffValidator;
             private readonly ErrorPresenter errorPresenter;
@@ -83,6 +81,9 @@ namespace BranchDiffer.VS.Shared.BranchDiff
                 this.solutionDirectory = solutionPath;
                 this.vsHierarchyItemCollectionProvider = vsHierarchyItemCollectionProvider;
                 this.Initialized += BranchDiffFilter_Initialized;
+
+
+                // Dependencies that can be moved to constructor and resolved via IoC...
                 this.branchDiffWorker = DIContainer.Instance.GetService(typeof(GitBranchDiffController)) as GitBranchDiffController;
                 this.branchDiffValidator = VsDIContainer.Instance.GetService(typeof(BranchDiffFilterValidator)) as BranchDiffFilterValidator;
                 this.errorPresenter = VsDIContainer.Instance.GetService(typeof(ErrorPresenter)) as ErrorPresenter;
@@ -102,7 +103,7 @@ namespace BranchDiffer.VS.Shared.BranchDiff
             protected override async Task<IReadOnlyObservableSet> GetIncludedItemsAsync(IEnumerable<IVsHierarchyItem> rootItems)
             {
                 if (this.branchDiffValidator.ValidateBranch(this.package))
-                {
+                {                    
                     // Create new tag tables everytime the filter is applied 
                     BranchDiffFilterProvider.TagManager.CreateTagTables();
                     IVsHierarchyItem root = HierarchyUtilities.FindCommonAncestor(rootItems);

--- a/src/BranchDiffer.VS.Shared/BranchDiff/BranchDiffFilterValidator.cs
+++ b/src/BranchDiffer.VS.Shared/BranchDiff/BranchDiffFilterValidator.cs
@@ -1,41 +1,42 @@
-﻿using BranchDiffer.VS.Utils;
-using System.Windows.Forms;
+﻿using BranchDiffer.VS.Shared.Utils;
 
-namespace BranchDiffer.VS.BranchDiff
+namespace BranchDiffer.VS.Shared.BranchDiff
 {
-    /// <summary>
-    /// Helper to make some prelimenary validations done by Filter on Package info and the Solution info set on it.
-    /// </summary>
-    public static class BranchDiffFilterValidator
+    public class BranchDiffFilterValidator
     {
-        public static bool ValidateBranch(IGitBranchDifferPackage package)
+        private readonly ErrorPresenter errorPresenter;
+
+        public BranchDiffFilterValidator(ErrorPresenter errorPresenter)
+        { 
+            this.errorPresenter = errorPresenter;
+        }
+
+        public bool ValidateBranch(IGitBranchDifferPackage package)
         {
             if (package is null)
             {
-                MessageBox.Show(
-                    "Unable to load Git Branch Differ plug-in. It is possible Visual Studio is still initializing, please wait and try again.",
-                    "Git Branch Differ");
+                this.errorPresenter.ShowError("Unable to load Git Branch Differ plug-in. It is possible Visual Studio is still initializing, please wait and try again.");
 
                 return false;
             }
 
             if (package.BranchToDiffAgainst is null || package.BranchToDiffAgainst == string.Empty)
             {
-                ErrorPresenter.ShowError("Branch to diff against is not set. Go to Options -> Git Branch Differ -> Set \"Branch To Diff Against\"");
+                this.errorPresenter.ShowError("Branch to diff against is not set. Go to Options -> Git Branch Differ -> Set \"Branch To Diff Against\"");
                 return false;
             }
 
             return true;
         }
 
-        public static bool ValidateSolution(string solutionDirectory, string solutionFile)
+        public bool ValidateSolution(string solutionDirectory)
         {
             // We set solution info from solution load event on the filter, and display the filter button at the same time,
             // so just to be safe, check if info was set before user clicked the button
-            if (string.IsNullOrEmpty(solutionDirectory) || string.IsNullOrEmpty(solutionFile))
+            if (string.IsNullOrEmpty(solutionDirectory))
             {
-                ErrorPresenter.ShowError(
-                       "Unable to get Solution from Visual Studio services.\n" +                       
+                this.errorPresenter.ShowError(
+                       "Unable to get Solution from Visual Studio services.\n" +
                        "If the error persists, please restart Visual Studio with this solution as the start-up solution.");
 
                 return false;

--- a/src/BranchDiffer.VS.Shared/BranchDiffer.VS.Shared.projitems
+++ b/src/BranchDiffer.VS.Shared/BranchDiffer.VS.Shared.projitems
@@ -15,8 +15,10 @@
     <Compile Include="$(MSBuildThisFileDirectory)FileDiff\Commands\OpenDiffCommand.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FileDiff\Commands\OpenPhysicalFileDiffCommand.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FileDiff\Commands\OpenProjectFileDiffCommand.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)FileDiff\Tables\EditedCsProjectTable.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FileDiff\ItemTagManager.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)FileDiff\RenamedPathTable.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)FileDiff\Tables\IItemTable.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)FileDiff\Tables\RenamedPathTable.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FileDiff\VsFileDiffProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GitBranchDifferPackage.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GitBranchDifferPluginOptions.cs">

--- a/src/BranchDiffer.VS.Shared/BranchDiffer.VS.Shared.projitems
+++ b/src/BranchDiffer.VS.Shared/BranchDiffer.VS.Shared.projitems
@@ -11,6 +11,7 @@
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)BranchDiff\BranchDiffFilterProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)BranchDiff\BranchDiffFilterValidator.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Configuration\VsDIContainer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FileDiff\Commands\OpenDiffCommand.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FileDiff\Commands\OpenPhysicalFileDiffCommand.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FileDiff\Commands\OpenProjectFileDiffCommand.cs" />

--- a/src/BranchDiffer.VS.Shared/Configuration/VsDIContainer.cs
+++ b/src/BranchDiffer.VS.Shared/Configuration/VsDIContainer.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using BranchDiffer.VS.Shared.BranchDiff;
+using BranchDiffer.VS.Shared.FileDiff.Commands;
 using BranchDiffer.VS.Shared.Utils;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -30,6 +31,8 @@ namespace BranchDiffer.VS.Shared.Configuration
             var services = new ServiceCollection();
             services.AddSingleton<ErrorPresenter>();
             services.AddSingleton<BranchDiffFilterValidator>();
+            services.AddSingleton<OpenPhysicalFileDiffCommand>();
+            services.AddSingleton<OpenProjectFileDiffCommand>();
             return services.BuildServiceProvider();
         }
     }

--- a/src/BranchDiffer.VS.Shared/Configuration/VsDIContainer.cs
+++ b/src/BranchDiffer.VS.Shared/Configuration/VsDIContainer.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using BranchDiffer.VS.Shared.BranchDiff;
+using BranchDiffer.VS.Shared.Utils;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace BranchDiffer.VS.Shared.Configuration
+{
+    /// <summary>
+    /// Resolves DI dependencies used in BranchDiffer.VS projects
+    /// </summary>
+    internal class VsDIContainer
+    {
+        private static IServiceProvider instance;
+
+        public static IServiceProvider Instance
+        {
+            get
+            {
+                if (instance == null)
+                {
+                    instance = BuildProvider();
+                }
+
+                return instance;
+            }
+        }
+
+        private static IServiceProvider BuildProvider()
+        {
+            var services = new ServiceCollection();
+            services.AddSingleton<ErrorPresenter>();
+            services.AddSingleton<BranchDiffFilterValidator>();
+            return services.BuildServiceProvider();
+        }
+    }
+}

--- a/src/BranchDiffer.VS.Shared/FileDiff/Commands/OpenDiffCommand.cs
+++ b/src/BranchDiffer.VS.Shared/FileDiff/Commands/OpenDiffCommand.cs
@@ -27,10 +27,10 @@ namespace BranchDiffer.VS.Shared.FileDiff.Commands
         {
             ThreadHelper.ThrowIfNotOnUIThread();
             this.package = package ?? throw new ArgumentNullException(nameof(package));
-            this.dte = package.GetServiceAsync(typeof(DTE)) as DTE ?? throw new ArgumentNullException(nameof(dte));
-            this.commandService = package.GetServiceAsync(typeof(IMenuCommandService)) as IMenuCommandService ?? throw new ArgumentNullException(nameof(commandService));
-            this.vsDifferenceService = package.GetServiceAsync(typeof(SVsDifferenceService)) as IVsDifferenceService ?? throw new ArgumentNullException(nameof(vsDifferenceService));
-            this.vsUIShell = package.GetServiceAsync(typeof(SVsUIShell)) as IVsUIShell ?? throw new ArgumentNullException(nameof(vsUIShell));
+            this.vsDifferenceService = package.GetService(typeof(SVsDifferenceService)) as IVsDifferenceService ?? throw new ArgumentNullException(nameof(vsDifferenceService));
+            this.commandService = package.GetService(typeof(IMenuCommandService)) as IMenuCommandService ?? throw new ArgumentNullException(nameof(commandService));
+            this.dte = package.GetService(typeof(DTE)) as DTE ?? throw new ArgumentNullException(nameof(dte));
+            this.vsUIShell = package.GetService(typeof(SVsUIShell)) as IVsUIShell ?? throw new ArgumentNullException(nameof(vsUIShell));
             this.errorPresenter = VsDIContainer.Instance.GetService(typeof(ErrorPresenter)) as ErrorPresenter ?? throw new ArgumentNullException(nameof(errorPresenter));
             this.gitFileDiffController = DIContainer.Instance.GetService(typeof(GitFileDiffController)) as GitFileDiffController ?? throw new ArgumentNullException(nameof(gitFileDiffController));
 

--- a/src/BranchDiffer.VS.Shared/FileDiff/Commands/OpenDiffCommand.cs
+++ b/src/BranchDiffer.VS.Shared/FileDiff/Commands/OpenDiffCommand.cs
@@ -1,15 +1,14 @@
 ﻿using BranchDiffer.Git.Configuration;
 using BranchDiffer.Git.Core;
-using BranchDiffer.VS.Shared.BranchDiff;
-using BranchDiffer.VS.Shared.Configuration;
 using BranchDiffer.VS.Shared.Models;
 using BranchDiffer.VS.Shared.Utils;
+using BranchDiffer.VS.Shared.Configuration;
 using EnvDTE;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using System;
 using System.ComponentModel.Design;
-using System.Threading.Tasks;
+using Task = System.Threading.Tasks.Task;
 
 namespace BranchDiffer.VS.Shared.FileDiff.Commands
 {

--- a/src/BranchDiffer.VS.Shared/FileDiff/Commands/OpenPhysicalFileDiffCommand.cs
+++ b/src/BranchDiffer.VS.Shared/FileDiff/Commands/OpenPhysicalFileDiffCommand.cs
@@ -4,7 +4,7 @@ using System.ComponentModel.Design;
 using BranchDiffer.VS.Shared.Utils;
 using BranchDiffer.VS.Shared.BranchDiff;
 using BranchDiffer.VS.Shared.Models;
-using System.Threading.Tasks;
+using Task = System.Threading.Tasks.Task;
 using System;
 
 namespace BranchDiffer.VS.Shared.FileDiff.Commands

--- a/src/BranchDiffer.VS.Shared/FileDiff/Commands/OpenPhysicalFileDiffCommand.cs
+++ b/src/BranchDiffer.VS.Shared/FileDiff/Commands/OpenPhysicalFileDiffCommand.cs
@@ -4,17 +4,16 @@ using System.ComponentModel.Design;
 using BranchDiffer.VS.Shared.Utils;
 using BranchDiffer.VS.Shared.BranchDiff;
 using BranchDiffer.VS.Shared.Models;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Shell.Interop;
 
 namespace BranchDiffer.VS.Shared.FileDiff.Commands
 {
     public sealed class OpenPhysicalFileDiffCommand : OpenDiffCommand
     {
-        private OpenPhysicalFileDiffCommand(IGitBranchDifferPackage package)
-            : base(package, new CommandID(GitBranchDifferPackageGuids.guidFileDiffPackageCmdSet, GitBranchDifferPackageGuids.CommandIdPhysicalFileDiffMenuCommand))
+        public OpenPhysicalFileDiffCommand()
         {
         }
-
-        public static OpenPhysicalFileDiffCommand Instance { get; private set; }
 
         public bool IsVisible 
         { 
@@ -23,11 +22,12 @@ namespace BranchDiffer.VS.Shared.FileDiff.Commands
         }
 
         /// <summary>
-        /// Initializes the singleton instance of the command.
+        /// Inits the dependecies needed to execute the command, then register command in VS menu
         /// </summary>
-        public static void Initialize(IGitBranchDifferPackage package)
-        {               
-            Instance = new OpenPhysicalFileDiffCommand(package);
+        public async Task InitializeAndRegisterAsync(IGitBranchDifferPackage package, EnvDTE.DTE dte, IVsUIShell vsUIShell)
+        {
+            await this.InitializeAsync(package, dte, vsUIShell);
+            this.Register(new CommandID(GitBranchDifferPackageGuids.guidFileDiffPackageCmdSet, GitBranchDifferPackageGuids.CommandIdPhysicalFileDiffMenuCommand));
         }
 
         protected override void OpenDiffWindow(object selectedObject)

--- a/src/BranchDiffer.VS.Shared/FileDiff/Commands/OpenProjectFileDiffCommand.cs
+++ b/src/BranchDiffer.VS.Shared/FileDiff/Commands/OpenProjectFileDiffCommand.cs
@@ -5,7 +5,7 @@ using EnvDTE;
 using Microsoft.VisualStudio.Shell;
 using System;
 using System.ComponentModel.Design;
-using System.Threading.Tasks;
+using Task = System.Threading.Tasks.Task;
 
 namespace BranchDiffer.VS.Shared.FileDiff.Commands
 {

--- a/src/BranchDiffer.VS.Shared/FileDiff/Commands/OpenProjectFileDiffCommand.cs
+++ b/src/BranchDiffer.VS.Shared/FileDiff/Commands/OpenProjectFileDiffCommand.cs
@@ -1,52 +1,51 @@
-﻿using BranchDiffer.VS.Utils;
+﻿using BranchDiffer.VS.Shared.BranchDiff;
+using BranchDiffer.VS.Shared.Models;
+using BranchDiffer.VS.Shared.Utils;
 using EnvDTE;
 using Microsoft.VisualStudio.Shell;
-using Microsoft.VisualStudio.Shell.Interop;
-using System;
 using System.ComponentModel.Design;
-using System.Globalization;
-using System.Threading;
-using System.Threading.Tasks;
-using Task = System.Threading.Tasks.Task;
 
-namespace BranchDiffer.VS.FileDiff.Commands
+namespace BranchDiffer.VS.Shared.FileDiff.Commands
 {
     public sealed class OpenProjectFileDiffCommand : OpenDiffCommand
     {
         private OpenProjectFileDiffCommand(
-            IGitBranchDifferPackage package,
-            DTE dte, 
-            IVsDifferenceService vsDifferenceService,
-            IVsUIShell vsUIShell,
-            OleMenuCommandService commandService)
-            : base(package,
-                 dte,
-                 vsDifferenceService,
-                 vsUIShell,
-                 commandService,
-                 new CommandID(
-                     GitBranchDifferPackageGuids.guidFileDiffPackageCmdSet,
-                     GitBranchDifferPackageGuids.CommandIdProjectFileDiffMenuCommand))
+            IGitBranchDifferPackage package)
+            : base(package, new CommandID(GitBranchDifferPackageGuids.guidFileDiffPackageCmdSet, GitBranchDifferPackageGuids.CommandIdProjectFileDiffMenuCommand))
         {
         }
 
 
         public static OpenProjectFileDiffCommand Instance { get; private set; }
 
-        public bool IsVisible { get => OleCommandInstance.Visible; set => OleCommandInstance.Visible = value; }
+        public bool IsVisible 
+        { 
+            get => OleCommandInstance.Visible; 
+            set => OleCommandInstance.Visible = value; 
+        }
 
         /// <summary>
         /// Initializes the singleton instance of the command.
         /// </summary>
-        public static async Task InitializeAsync(IGitBranchDifferPackage package)
+        public static void Initialize(IGitBranchDifferPackage package)
         {
-            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync(package.CancellationToken);
+            Instance = new OpenProjectFileDiffCommand(package);
+        }
 
-            DTE dte = await package.GetServiceAsync(typeof(DTE)) as DTE;
-            OleMenuCommandService commandService = await package.GetServiceAsync(typeof(IMenuCommandService)) as OleMenuCommandService;
-            IVsDifferenceService vsDifferenceService = await package.GetServiceAsync(typeof(SVsDifferenceService)) as IVsDifferenceService;
-            IVsUIShell vsUIShell = await package.GetServiceAsync(typeof(SVsUIShell)) as IVsUIShell;
-            Instance = new OpenProjectFileDiffCommand(package, dte, vsDifferenceService, vsUIShell, commandService);
+        protected override void OpenDiffWindow(object selectedObject)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+            if (selectedObject is Project)
+            {
+                var selectedProject = selectedObject as Project;
+                var oldPath = BranchDiffFilterProvider.TagManager.GetOldFilePathFromRenamed(selectedProject);
+                var selection = new SolutionSelectionContainer<ISolutionSelection>
+                {
+                    Item = new SelectedProject { Native = selectedProject, OldFullPath = oldPath }
+                };
+
+                this.ShowFileDiffWindow(selection);
+            }
         }
     }
 }

--- a/src/BranchDiffer.VS.Shared/FileDiff/Commands/OpenProjectFileDiffCommand.cs
+++ b/src/BranchDiffer.VS.Shared/FileDiff/Commands/OpenProjectFileDiffCommand.cs
@@ -3,33 +3,31 @@ using BranchDiffer.VS.Shared.Models;
 using BranchDiffer.VS.Shared.Utils;
 using EnvDTE;
 using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
 using System.ComponentModel.Design;
+using System.Threading.Tasks;
 
 namespace BranchDiffer.VS.Shared.FileDiff.Commands
 {
     public sealed class OpenProjectFileDiffCommand : OpenDiffCommand
     {
-        private OpenProjectFileDiffCommand(
-            IGitBranchDifferPackage package)
-            : base(package, new CommandID(GitBranchDifferPackageGuids.guidFileDiffPackageCmdSet, GitBranchDifferPackageGuids.CommandIdProjectFileDiffMenuCommand))
+        public OpenProjectFileDiffCommand()
         {
         }
-
-
-        public static OpenProjectFileDiffCommand Instance { get; private set; }
 
         public bool IsVisible 
         { 
             get => OleCommandInstance.Visible; 
-            set => OleCommandInstance.Visible = value; 
+            set => OleCommandInstance.Visible = value;
         }
 
         /// <summary>
-        /// Initializes the singleton instance of the command.
+        /// Inits the dependecies needed to execute the command, then register command in VS menu
         /// </summary>
-        public static void Initialize(IGitBranchDifferPackage package)
+        public async Task InitializeAndRegisterAsync(IGitBranchDifferPackage package, EnvDTE.DTE dte, IVsUIShell vsUIShell)
         {
-            Instance = new OpenProjectFileDiffCommand(package);
+            await this.InitializeAsync(package, dte, vsUIShell);
+            this.Register(new CommandID(GitBranchDifferPackageGuids.guidFileDiffPackageCmdSet, GitBranchDifferPackageGuids.CommandIdProjectFileDiffMenuCommand));
         }
 
         protected override void OpenDiffWindow(object selectedObject)

--- a/src/BranchDiffer.VS.Shared/FileDiff/ItemTagManager.cs
+++ b/src/BranchDiffer.VS.Shared/FileDiff/ItemTagManager.cs
@@ -1,51 +1,77 @@
-﻿using Microsoft.VisualStudio.Shell.Interop;
+﻿using BranchDiffer.VS.Shared.FileDiff.Tables;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
 
 namespace BranchDiffer.VS.Shared.FileDiff
 {
     /// <summary>
-    /// Tags an item in the SolutionExplorer hierarchy with the old path (the path it has in the branch against which we diff working branch)
+    /// Holds tables that contain extra info on SolutionExplorer nodes (if the file corresponding that node was renamed, or if the .csproj file behind the proj node was edited).
+    /// The tables are filled in when filter is applied.
     /// </summary>
     public class ItemTagManager
     {
         private RenamedPathTable<EnvDTE.ProjectItem> renamedProjectItemTable;
         private RenamedPathTable<EnvDTE.Project> renamedCsProjectTable;
+        private EditedCsProjectTable editedCsProjectTable;
 
         public void CreateTagTables()
         {
             // Does not support Clear(), so we dispose the tables, create new
             this.renamedProjectItemTable?.Dispose();
             this.renamedCsProjectTable?.Dispose();
+            this.editedCsProjectTable?.Dispose();
             this.renamedProjectItemTable = new RenamedPathTable<EnvDTE.ProjectItem>();
             this.renamedCsProjectTable = new RenamedPathTable<EnvDTE.Project>();
+            this.editedCsProjectTable = new EditedCsProjectTable();
         }
 
+        /*
+         * Methods to manage csproj objects that were added/edited/renamed in working branch
+         */
+        public void MarkProjAsChanged(IVsHierarchyItem vsHierarchyItem)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+            var vsHierarchy = vsHierarchyItem.HierarchyIdentity.Hierarchy;
+            vsHierarchy.ParseCanonicalName(vsHierarchyItem.CanonicalName, out uint itemId);
+            vsHierarchy.GetProperty(itemId, (int)__VSHPROPID.VSHPROPID_ExtObject, out object itemObject);
+            var project = itemObject as EnvDTE.Project;
+            this.editedCsProjectTable.Insert(project, project.FullName);
+        }
+
+        public bool IsCsProjEdited(EnvDTE.Project project)
+        {            
+            return this.editedCsProjectTable.Select(project) is null ? false : true; 
+        }
+
+        /*
+         * Methods to manage files that were renamed in working branch
+         */
         public string GetOldFilePathFromRenamed(EnvDTE.Project project)
         {
-            Microsoft.VisualStudio.Shell.ThreadHelper.ThrowIfNotOnUIThread();
-            return this.renamedCsProjectTable.GetValue(project);
+            return this.renamedCsProjectTable.Select(project);
         }
 
         public string GetOldFilePathFromRenamed(EnvDTE.ProjectItem projectItem)
         {
-            Microsoft.VisualStudio.Shell.ThreadHelper.ThrowIfNotOnUIThread();
-            return this.renamedProjectItemTable.GetValue(projectItem);
+            return this.renamedProjectItemTable.Select(projectItem);
         }
 
-        public void SetOldFilePathOnRenamedItem(IVsHierarchy vsHierarchy, string itemCanonicalName, string oldPath)
+        public void SetOldFilePathOnRenamedItem(IVsHierarchyItem vsHierarchyItem, string oldPath)
         {
             Microsoft.VisualStudio.Shell.ThreadHelper.ThrowIfNotOnUIThread();
-            vsHierarchy.ParseCanonicalName(itemCanonicalName, out uint itemId);
+            var vsHierarchy = vsHierarchyItem.HierarchyIdentity.Hierarchy;            
+            vsHierarchy.ParseCanonicalName(vsHierarchyItem.CanonicalName, out uint itemId);
             vsHierarchy.GetProperty(itemId, (int)__VSHPROPID.VSHPROPID_ExtObject, out object itemObject);
             var projectItem = itemObject as EnvDTE.ProjectItem;
             if (projectItem != null)
             {
-                this.renamedProjectItemTable.Set(projectItem, oldPath);
+                this.renamedProjectItemTable.Insert(projectItem, oldPath);
             }
 
             var project = itemObject as EnvDTE.Project;
             if (project != null)
             {
-                this.renamedCsProjectTable.Set(project, oldPath);
+                this.renamedCsProjectTable.Insert(project, oldPath);
             }
         }
     }

--- a/src/BranchDiffer.VS.Shared/FileDiff/ItemTagManager.cs
+++ b/src/BranchDiffer.VS.Shared/FileDiff/ItemTagManager.cs
@@ -1,6 +1,6 @@
 ﻿using Microsoft.VisualStudio.Shell.Interop;
 
-namespace BranchDiffer.VS.FileDiff
+namespace BranchDiffer.VS.Shared.FileDiff
 {
     /// <summary>
     /// Tags an item in the SolutionExplorer hierarchy with the old path (the path it has in the branch against which we diff working branch)

--- a/src/BranchDiffer.VS.Shared/FileDiff/ItemTagManager.cs
+++ b/src/BranchDiffer.VS.Shared/FileDiff/ItemTagManager.cs
@@ -35,6 +35,9 @@ namespace BranchDiffer.VS.Shared.FileDiff
             vsHierarchy.ParseCanonicalName(vsHierarchyItem.CanonicalName, out uint itemId);
             vsHierarchy.GetProperty(itemId, (int)__VSHPROPID.VSHPROPID_ExtObject, out object itemObject);
             var project = itemObject as EnvDTE.Project;
+
+            // No need of passing project.FullName, all we need is to store and retrive the project object later,
+            // but since the ConditionalWeakTable is a dictionary-like object, we pass it as a value.
             this.editedCsProjectTable.Insert(project, project.FullName);
         }
 

--- a/src/BranchDiffer.VS.Shared/FileDiff/RenamedPathTable.cs
+++ b/src/BranchDiffer.VS.Shared/FileDiff/RenamedPathTable.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
 
-namespace BranchDiffer.VS.FileDiff
+namespace BranchDiffer.VS.Shared.FileDiff
 {
     /// <summary>
     /// TKey can be either ProjectItem or Project

--- a/src/BranchDiffer.VS.Shared/FileDiff/Tables/EditedCsProjectTable.cs
+++ b/src/BranchDiffer.VS.Shared/FileDiff/Tables/EditedCsProjectTable.cs
@@ -1,30 +1,30 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Text;
 
-namespace BranchDiffer.VS.Shared.FileDiff
+namespace BranchDiffer.VS.Shared.FileDiff.Tables
 {
     /// <summary>
-    /// TKey can be either ProjectItem or Project
+    /// Holds a table of .csproj files that were added/edited.
+    /// We lookup this table and then make "Open Diff With Base" menu command visible for Project node in Solution Explorer.
     /// </summary>
-    public class RenamedPathTable<TKey> : IDisposable
-        where TKey : class
+    internal class EditedCsProjectTable : IItemTable<EnvDTE.Project, string>
     {
-        private ConditionalWeakTable<TKey, string> conditionalWeakTable;
+        private ConditionalWeakTable<EnvDTE.Project, string> conditionalWeakTable;
 
-        public RenamedPathTable()
+        public EditedCsProjectTable()
         {
-            conditionalWeakTable = new ConditionalWeakTable<TKey, string>();
+            conditionalWeakTable = new ConditionalWeakTable<EnvDTE.Project, string>();
         }
 
-        public string GetValue(TKey key)
+        public string Select(EnvDTE.Project key)
         {
             this.conditionalWeakTable.TryGetValue(key, out string value);
             return value;
         }
 
-        public void Set(TKey key, string value)
+        public void Insert(EnvDTE.Project key, string value)
         {
             this.conditionalWeakTable.Add(key, value);
         }

--- a/src/BranchDiffer.VS.Shared/FileDiff/Tables/IItemTable.cs
+++ b/src/BranchDiffer.VS.Shared/FileDiff/Tables/IItemTable.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace BranchDiffer.VS.Shared.FileDiff.Tables
+{
+    // TKey is the Solution object (either ProjectItem or Project)
+    internal interface IItemTable<TKey, TValue> : IDisposable
+    {
+        void Insert(TKey item, TValue value);
+
+        TValue Select(TKey item);
+    }
+}

--- a/src/BranchDiffer.VS.Shared/FileDiff/Tables/RenamedPathTable.cs
+++ b/src/BranchDiffer.VS.Shared/FileDiff/Tables/RenamedPathTable.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+
+namespace BranchDiffer.VS.Shared.FileDiff.Tables
+{
+    /// <summary>
+    /// Holds solution object that were renamed in working branch. The table contains the path of the same object in base branch.
+    /// </summary>
+    public class RenamedPathTable<TKey> : IItemTable<TKey, string>
+        where TKey : class
+    {
+        private ConditionalWeakTable<TKey, string> conditionalWeakTable;
+
+        public RenamedPathTable()
+        {
+            conditionalWeakTable = new ConditionalWeakTable<TKey, string>();
+        }
+
+        public string Select(TKey key)
+        {
+            this.conditionalWeakTable.TryGetValue(key, out string value);
+            return value;
+        }
+
+        public void Insert(TKey key, string value)
+        {
+            this.conditionalWeakTable.Add(key, value);
+        }
+
+        /// <summary>
+        /// I meant to clear all values of the weak table everytime the branch diff filter is un-applied, 
+        /// but ConditionalWeakTable does not have Clear() method in .NET framework, so we dispose try force garbage-collect the object
+        /// </summary>
+        public void Dispose()
+        {
+            this.conditionalWeakTable = null;
+            GC.Collect();
+        }
+    }
+}

--- a/src/BranchDiffer.VS.Shared/FileDiff/VsFileDiffProvider.cs
+++ b/src/BranchDiffer.VS.Shared/FileDiff/VsFileDiffProvider.cs
@@ -9,6 +9,7 @@ using Microsoft.VisualStudio.Shell.Interop;
 
 namespace BranchDiffer.VS.FileDiff
 {
+    // TODO: Try to setup DI in VS project and resolve IVSServices using IGitBranchDifferPackage.GetServiceAsyn
     public class VsFileDiffProvider
     {
         private readonly IVsDifferenceService vsDifferenceService;

--- a/src/BranchDiffer.VS.Shared/FileDiff/VsFileDiffProvider.cs
+++ b/src/BranchDiffer.VS.Shared/FileDiff/VsFileDiffProvider.cs
@@ -1,26 +1,34 @@
-﻿using BranchDiffer.Git.Configuration;
-using BranchDiffer.Git.Core;
+﻿using BranchDiffer.Git.Core;
 using BranchDiffer.Git.Exceptions;
 using BranchDiffer.Git.Models;
-using BranchDiffer.VS.Models;
-using BranchDiffer.VS.Utils;
-using Microsoft;
+using BranchDiffer.VS.Shared.Models;
+using BranchDiffer.VS.Shared.Utils;
 using Microsoft.VisualStudio.Shell.Interop;
 
-namespace BranchDiffer.VS.FileDiff
+namespace BranchDiffer.VS.Shared.FileDiff
 {
-    // TODO: Try to setup DI in VS project and resolve IVSServices using IGitBranchDifferPackage.GetServiceAsyn
     public class VsFileDiffProvider
     {
-        private readonly IVsDifferenceService vsDifferenceService;
         private readonly string DocumentPath;
         private readonly string OldDocumentPath;
         private readonly string solutionPath;
 
-        public VsFileDiffProvider(IVsDifferenceService vsDifferenceService, string solutionPath, SolutionSelectionContainer<ISolutionSelection> selectionContainer)
+        // Resolvable dependencies...
+        private readonly ErrorPresenter errorPresenter;
+        private readonly IVsDifferenceService vsDifferenceService;
+        private readonly GitFileDiffController gitFileDiffController;
+
+        public VsFileDiffProvider(
+            IVsDifferenceService vsDifferenceService, 
+            string solutionPath, 
+            SolutionSelectionContainer<ISolutionSelection> selectionContainer, 
+            ErrorPresenter errorPresenter, 
+            GitFileDiffController gitFileDiffController)
         {
             this.vsDifferenceService = vsDifferenceService;
             this.solutionPath = solutionPath;
+            this.errorPresenter = errorPresenter;
+            this.gitFileDiffController = gitFileDiffController;
             this.DocumentPath = selectionContainer.FullName;
             this.OldDocumentPath = selectionContainer.OldFullName;
         }
@@ -28,22 +36,20 @@ namespace BranchDiffer.VS.FileDiff
         public void ShowFileDiffWithBaseBranch(string baseBranchToDiffAgainst)
         {
             Microsoft.VisualStudio.Shell.ThreadHelper.ThrowIfNotOnUIThread();
-            var fileDiffController = DIContainer.Instance.GetService(typeof(GitFileDiffController)) as GitFileDiffController;
-            Assumes.Present(fileDiffController);
 
             // Get branch pairs to diff and Get the revision of file in the branch-to-diff-against
             try
             {
-                var branchPairs = fileDiffController.GetDiffBranchPair(this.solutionPath, baseBranchToDiffAgainst);
+                var branchPairs = this.gitFileDiffController.GetDiffBranchPair(this.solutionPath, baseBranchToDiffAgainst);
                 var baseBranchFilePath = string.IsNullOrEmpty(this.OldDocumentPath) ? this.DocumentPath : this.OldDocumentPath;
-                var leftFileMoniker = fileDiffController.GetBaseBranchRevisionOfFile(this.solutionPath, baseBranchToDiffAgainst, baseBranchFilePath);
+                var leftFileMoniker = this.gitFileDiffController.GetBaseBranchRevisionOfFile(this.solutionPath, baseBranchToDiffAgainst, baseBranchFilePath);
                 var rightFileMoniker = this.DocumentPath;
 
                 this.PresentComparisonWindow(branchPairs, leftFileMoniker, rightFileMoniker);
             }
             catch (GitOperationException e)
             {
-                ErrorPresenter.ShowError(e.Message);
+                this.errorPresenter.ShowError(e.Message);
             }
         }
 

--- a/src/BranchDiffer.VS.Shared/FileDiff/VsFileDiffProvider.cs
+++ b/src/BranchDiffer.VS.Shared/FileDiff/VsFileDiffProvider.cs
@@ -53,6 +53,7 @@ namespace BranchDiffer.VS.Shared.FileDiff
             }
         }
 
+        // TODO : When file are renamed in working branch, left-file should be labled as with old-file-name@base-branch.
         private void PresentComparisonWindow(DiffBranchPair branchDiffPair, string leftFileMoniker, string rightFileMoniker)
         {
             Microsoft.VisualStudio.Shell.ThreadHelper.ThrowIfNotOnUIThread();            

--- a/src/BranchDiffer.VS.Shared/FileDiff/VsFileDiffProvider.cs
+++ b/src/BranchDiffer.VS.Shared/FileDiff/VsFileDiffProvider.cs
@@ -7,6 +7,7 @@ using Microsoft.VisualStudio.Shell.Interop;
 
 namespace BranchDiffer.VS.Shared.FileDiff
 {
+    // TODO: Make this injectible
     public class VsFileDiffProvider
     {
         private readonly string DocumentPath;
@@ -53,7 +54,7 @@ namespace BranchDiffer.VS.Shared.FileDiff
             }
         }
 
-        // TODO : When file are renamed in working branch, left-file should be labled as with old-file-name@base-branch.
+        // TODO: When file are renamed in working branch, left-file should be labled as with old-file-name@base-branch.
         private void PresentComparisonWindow(DiffBranchPair branchDiffPair, string leftFileMoniker, string rightFileMoniker)
         {
             Microsoft.VisualStudio.Shell.ThreadHelper.ThrowIfNotOnUIThread();            

--- a/src/BranchDiffer.VS.Shared/GitBranchDifferPackage.cs
+++ b/src/BranchDiffer.VS.Shared/GitBranchDifferPackage.cs
@@ -91,7 +91,6 @@ namespace BranchDiffer.VS.Shared
             ThreadHelper.ThrowIfNotOnUIThread();
             var absoluteSolutionPath = this.dte.Solution.FullName;
             var solutionDirectory = System.IO.Path.GetDirectoryName(absoluteSolutionPath);
-            var solutionFile = System.IO.Path.GetFileName(absoluteSolutionPath);
             BranchDiffFilterProvider.SetSolutionInfo(solutionDirectory);
         }
 

--- a/src/BranchDiffer.VS.Shared/GitBranchDifferPackage.cs
+++ b/src/BranchDiffer.VS.Shared/GitBranchDifferPackage.cs
@@ -33,8 +33,6 @@ namespace BranchDiffer.VS.Shared
             BranchDiffFilterProvider.Initialize(this);
         }
 
-        // TODO: Move all Init code to MEF component (MEF component loading is not async however, and slow down loading),
-        // but lot of code will be simplifed without the ugly static objects set on BranchDiffFilterProvider.
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "VSSDK006:Check services exist", Justification = "Show custom error if DTE service doesn't exist")]
         protected override async Task InitializeAsync(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)
         {

--- a/src/BranchDiffer.VS.Shared/GitBranchDifferPluginOptions.cs
+++ b/src/BranchDiffer.VS.Shared/GitBranchDifferPluginOptions.cs
@@ -2,7 +2,7 @@
 using Microsoft.VisualStudio.Shell;
 using System.ComponentModel;
 
-namespace BranchDiffer.VS
+namespace BranchDiffer.VS.Shared
 {
     public class GitBranchDifferPluginOptions : DialogPage
     {

--- a/src/BranchDiffer.VS.Shared/IGitBranchDifferPackage.cs
+++ b/src/BranchDiffer.VS.Shared/IGitBranchDifferPackage.cs
@@ -1,7 +1,7 @@
 ﻿using Microsoft.VisualStudio.Shell;
 using System.Threading;
 
-namespace BranchDiffer.VS
+namespace BranchDiffer.VS.Shared
 {
     /// <summary>
     /// Provides access to the implementation of VSPackage in startup project.

--- a/src/BranchDiffer.VS.Shared/IGitBranchDifferPackage.cs
+++ b/src/BranchDiffer.VS.Shared/IGitBranchDifferPackage.cs
@@ -11,9 +11,5 @@ namespace BranchDiffer.VS.Shared
         string BranchToDiffAgainst { get; }
 
         CancellationToken CancellationToken { get; }
-
-        void OnFilterApplied();
-
-        void OnFilterUnapplied();
     }
 }

--- a/src/BranchDiffer.VS.Shared/IGitBranchDifferPackage.cs
+++ b/src/BranchDiffer.VS.Shared/IGitBranchDifferPackage.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿using Microsoft.VisualStudio.Shell;
 using System.Threading;
 
 namespace BranchDiffer.VS.Shared
@@ -6,7 +6,7 @@ namespace BranchDiffer.VS.Shared
     /// <summary>
     /// Provides access to the implementation of VSPackage in startup project.
     /// </summary>
-    public interface IGitBranchDifferPackage : IServiceProvider
+    public interface IGitBranchDifferPackage : IAsyncServiceProvider
     {
         string BranchToDiffAgainst { get; }
 

--- a/src/BranchDiffer.VS.Shared/IGitBranchDifferPackage.cs
+++ b/src/BranchDiffer.VS.Shared/IGitBranchDifferPackage.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.VisualStudio.Shell;
+﻿using System;
 using System.Threading;
 
 namespace BranchDiffer.VS.Shared
@@ -6,7 +6,7 @@ namespace BranchDiffer.VS.Shared
     /// <summary>
     /// Provides access to the implementation of VSPackage in startup project.
     /// </summary>
-    public interface IGitBranchDifferPackage : IAsyncServiceProvider
+    public interface IGitBranchDifferPackage : IServiceProvider
     {
         string BranchToDiffAgainst { get; }
 

--- a/src/BranchDiffer.VS.Shared/Models/ISolutionSelection.cs
+++ b/src/BranchDiffer.VS.Shared/Models/ISolutionSelection.cs
@@ -1,6 +1,6 @@
 ﻿using EnvDTE;
 
-namespace BranchDiffer.VS.Models
+namespace BranchDiffer.VS.Shared.Models
 {
     public interface ISolutionSelection
     {

--- a/src/BranchDiffer.VS.Shared/Models/SelectedProject.cs
+++ b/src/BranchDiffer.VS.Shared/Models/SelectedProject.cs
@@ -1,6 +1,6 @@
 ﻿using EnvDTE;
 
-namespace BranchDiffer.VS.Models
+namespace BranchDiffer.VS.Shared.Models
 {
     public class SelectedProject : ISolutionSelection
     {

--- a/src/BranchDiffer.VS.Shared/Models/SelectedProjectItem.cs
+++ b/src/BranchDiffer.VS.Shared/Models/SelectedProjectItem.cs
@@ -1,6 +1,6 @@
 ﻿using EnvDTE;
 
-namespace BranchDiffer.VS.Models
+namespace BranchDiffer.VS.Shared.Models
 {
     public class SelectedProjectItem : ISolutionSelection
     {

--- a/src/BranchDiffer.VS.Shared/Models/SelectedProjectItem.cs
+++ b/src/BranchDiffer.VS.Shared/Models/SelectedProjectItem.cs
@@ -19,9 +19,9 @@ namespace BranchDiffer.VS.Models
         {
             get
             {
-                // BUG: Null Ref Exception when opening Diff for Solution Items, Properties is null, implement a different way to get their FullPath
+                // If Properties is null, use FileNames[] array to get physical path of the ProjectItem. No idea why it is 1-based index.
                 Microsoft.VisualStudio.Shell.ThreadHelper.ThrowIfNotOnUIThread();
-                return Native.Properties.Item("FullPath")?.Value.ToString();
+                return Native.Properties is null ? Native.FileNames[1] : Native.Properties.Item("FullPath")?.Value.ToString();
             }
         }
 

--- a/src/BranchDiffer.VS.Shared/Models/SolutionSelectionContainer.cs
+++ b/src/BranchDiffer.VS.Shared/Models/SolutionSelectionContainer.cs
@@ -1,4 +1,4 @@
-﻿namespace BranchDiffer.VS.Models
+﻿namespace BranchDiffer.VS.Shared.Models
 {
     public class SolutionSelectionContainer<T>
         where T : ISolutionSelection

--- a/src/BranchDiffer.VS.Shared/Models/SolutionSelectionExtensions.cs
+++ b/src/BranchDiffer.VS.Shared/Models/SolutionSelectionExtensions.cs
@@ -7,7 +7,7 @@ using Microsoft.VisualStudio.Text.Differencing;
 using System;
 using System.Collections.Generic;
 
-namespace BranchDiffer.VS.Models
+namespace BranchDiffer.VS.Shared.Models
 {
     internal static class SolutionSelectionExtensions
     {

--- a/src/BranchDiffer.VS.Shared/Utils/ErrorPresenter.cs
+++ b/src/BranchDiffer.VS.Shared/Utils/ErrorPresenter.cs
@@ -7,13 +7,13 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 
-namespace BranchDiffer.VS.Utils
+namespace BranchDiffer.VS.Shared.Utils
 {
-    public static class ErrorPresenter
+    public class ErrorPresenter
     {
-        private static string PackageNameToDisplay = "Git Branch Differ";
+        private const string PackageNameToDisplay = "Git Branch Differ";
 
-        public static void ShowError(string error)
+        public void ShowError(string error)
         {
             MessageBox.Show(
                 error,

--- a/src/BranchDiffer.VS.Shared/Utils/GitBranchDifferPackageGuids.cs
+++ b/src/BranchDiffer.VS.Shared/Utils/GitBranchDifferPackageGuids.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace BranchDiffer.VS.Utils
+namespace BranchDiffer.VS.Shared.Utils
 {
     public static class GitBranchDifferPackageGuids
     {

--- a/src/GitBranchDiffer/LICENSE.txt
+++ b/src/GitBranchDiffer/LICENSE.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Sajal Verma
+Copyright (c) 2022 Sajal Verma
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/GitBranchDiffer2019/LICENSE.txt
+++ b/src/GitBranchDiffer2019/LICENSE.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Sajal Verma
+Copyright (c) 2022 Sajal Verma
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Fixes #32 
1 Fixed bug for Opening diff against solution items resulting in null reference
2 Fixed C++ headers also showing up under "External Dependencies" in Solution Explorer view
3 Fixed major bug to make "Open Diff With Base" on .csproj files working. 

Refactoring on VS-specific code. 

TODO:
Fix builds and test with PR build artifacts. Added new Nuget dependency in VS.Shared project code which might cause issues when VSIX compiles for two diff targets (VS2019 and VS2022).